### PR TITLE
feat: bump node-mbus 2.2.2 to 2.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "jsonfile": "^6.1.0",
-        "node-mbus": "^2.2.2",
+        "node-mbus": "^2.2.4",
         "serialport": "^12.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "jsonfile": "^6.1.0",
-    "node-mbus": "^2.2.2",
+    "node-mbus": "^2.2.4",
     "serialport": "^12.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To make it compatible with Node.js 20 and 22.
Also tested with Node.js 18.

Reference: https://github.com/Apollon77/node-mbus/pull/125